### PR TITLE
Ignore machine readable comments

### DIFF
--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -132,7 +132,15 @@ func checkExported(
 	elementExported bool,
 	recvExported bool,
 ) {
-	if comment != nil || !elementExported {
+	commented := false
+	// We only want to report missing comments if we haven't already reported the
+	// comment is empty.
+	if comment != nil {
+		commented = len(comment.Text()) > 0 ||
+			!containsOnlyMachineReadableComment(comment)
+	}
+
+	if commented || !elementExported {
 		return
 	}
 
@@ -144,8 +152,6 @@ func checkExported(
 			commentMissingTmpl,
 			elementName,
 		)
-
-		return
 	}
 }
 

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -598,6 +598,57 @@ func (s *CommentMimicSuite) TestHandlesExtraWhitespace() {
 	analysistest.Run(t, dir, mimic, "a")
 }
 
+func (s *CommentMimicSuite) TestMachineCommentsMismatch() {
+	t := s.T()
+	flags := map[string]bool{
+		"comment-exported":     true,
+		"comment-all-exported": true,
+		"comment-interfaces":   true,
+	}
+
+	fileMap := map[string]string{
+		"a/a.go": testdata.EmptyComments,
+	}
+
+	dir, cleanup, err := analysistest.WriteFiles(fileMap)
+	require.NoError(t, err)
+
+	defer cleanup()
+
+	mimic := analyzer.NewCommentMimic()
+
+	for flag, value := range flags {
+		require.NoError(t, mimic.Flags.Set(flag, strconv.FormatBool(value)))
+	}
+
+	analysistest.Run(t, dir, mimic, "a")
+}
+
+func (s *CommentMimicSuite) TestMachineCommentsOnExported() {
+	t := s.T()
+	flags := map[string]bool{
+		"comment-all-exported": true,
+		"comment-interfaces":   true,
+	}
+
+	fileMap := map[string]string{
+		"a/a.go": testdata.MachineReadableExported,
+	}
+
+	dir, cleanup, err := analysistest.WriteFiles(fileMap)
+	require.NoError(t, err)
+
+	defer cleanup()
+
+	mimic := analyzer.NewCommentMimic()
+
+	for flag, value := range flags {
+		require.NoError(t, mimic.Flags.Set(flag, strconv.FormatBool(value)))
+	}
+
+	analysistest.Run(t, dir, mimic, "a")
+}
+
 func (s *CommentMimicSuite) TestFuncCommentErrors() {
 	element := "element"
 	base := generateCommentMimicCases(element)

--- a/pkg/analyzer/testdata/out_of_scope.go
+++ b/pkg/analyzer/testdata/out_of_scope.go
@@ -108,31 +108,6 @@ type (
 )
 `
 
-	EmptyComments = `package a
-
-  //  // want "first word of comment is '' instead of 'a'"
-  func a() bool {
-    return false
-  }
-
-  type b struct {}
-
-  //  // want "first word of comment is '' instead of 'c'"
-  func (ab b) c() bool {
-    return false
-  }
-
-  //  // want "first word of comment is '' instead of 'd'"
-  func (ab *b) d() bool {
-    return false
-  }
-
-  type e interface {
-    //  // want "first word of comment is '' instead of 'f'"
-    f() bool
-  }
-`
-
 	ExtraWhitespace = `package a
 
 // 	Element0 has a comment.
@@ -160,6 +135,77 @@ Element3	has a comment.
 */
 func Element3() bool {
   return false
+}
+`
+
+	EmptyComments = `package a
+
+//nolint:commentmimic
+func ignoreMachineReadable() bool {
+  return false
+}
+
+//nolint:commentmimic // want "first word of comment is 'This' instead of 'CommentMismatch'"
+// This function has a comment.
+func CommentMismatch() bool {
+  return false
+}
+
+//nolint:commentmimic
+//
+func EmptyComment() bool { // want "empty comment on 'EmptyComment'"
+  return false
+}
+
+//nolint:commentmimic
+//	
+func EmptyComment2() bool { // want "empty comment on 'EmptyComment2'"
+  return false
+}
+
+//nolint:commentmimic
+/*
+*/
+func EmptyComment3() bool { // want "empty comment on 'EmptyComment3'"
+  return false
+}
+
+//nolint:commentmimic
+/*
+   
+*/
+func EmptyComment4() bool { // want "empty comment on 'EmptyComment4'"
+  return false
+}
+`
+
+	MachineReadableExported = `package a
+
+//nolint:commentmimic
+func FreeFunc() bool { // want "exported element 'FreeFunc' should be commented"
+  return false
+}
+
+type testStruct struct {}
+
+//nolint:commentmimic
+func (t testStruct) PrivateReceiver() bool { // want "exported element 'PrivateReceiver' should be commented"
+  return false
+}
+
+//nolint:commentmimic
+func (t *testStruct) PrivatePtrReceiver() bool { // want "exported element 'PrivatePtrReceiver' should be commented"
+  return false
+}
+
+//nolint:commentmimic
+type TestInterface interface { // want "exported element 'TestInterface' should be commented"
+  ExportedInterfaceFunc() bool // want "exported element 'ExportedInterfaceFunc' should be commented"
+}
+
+//nolint:commentmimic
+type testIface interface {
+  UnexportedInterfaceFunc() bool // want "exported element 'UnexportedInterfaceFunc' should be commented"
 }
 `
 )

--- a/testdata/script/empty_comment.txtar
+++ b/testdata/script/empty_comment.txtar
@@ -1,5 +1,5 @@
 ! exec commentmimic empty_comment.go
-stderr -count=6 'first word of comment is '''' instead of ''func[1-6]'''
+stderr -count=6 'empty comment on ''func[1-6]'''
 
 -- empty_comment.go --
 package empty_comment


### PR DESCRIPTION
Ignore comments that are just machine-readable comments. This means if the comment is on an exported element and the element doesn't have other comments attached to it it will output a notice. If the comment is the only comment attached to something don't output anything about a mismatch.

Better handle empty comments as well. Use a new message that explicitly states the comment is empty and make sure it doesn't also output a comment about an exported element not being commented.